### PR TITLE
Fix crash on updating song length when there is no current entry

### DIFF
--- a/Sidplay3/Sidplay3windows.cpp
+++ b/Sidplay3/Sidplay3windows.cpp
@@ -974,8 +974,14 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 			if (myPlayList)
 			{
 				PlayListEntry* curEntry = myPlayList->Cur();
-
-				tuneLength = curEntry->PlayTime();
+				if (curEntry)
+				{
+					tuneLength = curEntry->PlayTime();
+				}
+				else
+				{
+					tuneLength = 0;
+				}
 			}
 			else
 			{


### PR DESCRIPTION
When no sid tune was loaded and nothing was currently selected in the playlist, it crashed immediately after setting the location of HVSC.
This was caused by an attempt to set song length to that of the currently selected entry in the playlist after updating the settings.
This pull request sets song length to 0 under these conditions to avoid a crash.